### PR TITLE
Adds a simple MANIFEST to copy in data files to pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include simdna/resources/*.gz


### PR DESCRIPTION
An attempt at addressing #6 by adding in a Pypi `MANIFEST.in` file that specifies that the two data files should be packaged in the build.

CC @lilleswing 